### PR TITLE
update to 2018 & implement Deserialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/webmanifest"
 description = "Create a manifest.webmanifest file"
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 serde = "1.0.79"

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ use webmanifest::{Manifest, Related};
 fn main() -> Result<(), failure::Error> {
   let name = "My Cool Application";
   let url = "https://play.google.com/store/apps/details?id=cheeaun.hackerweb";
-  let manifest = Manifest::builder(name)
-    .short_name("my app")
-    .bg_color("#000")
+  let manifest = Manifest::builder(name.into())
+    .short_name("my app".into())
+    .bg_color("#000".into())
     .related(&Related::new("play", url))
     .build()?;
   Ok(())

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ Create a `manifest.webmanifest` file.
 ## Examples
 ### Create a new manifest
 ```rust
-extern crate webmanifest;
-extern crate failure;
-
 use webmanifest::{Manifest, Related};
 
 fn main() -> Result<(), failure::Error> {

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,14 +1,11 @@
-extern crate failure;
-extern crate webmanifest;
-
 use webmanifest::{Icon, Manifest, Related};
 
 fn main() -> Result<(), failure::Error> {
   let name = "My Cool Application";
   let url = "https://play.google.com/store/apps/details?id=cheeaun.hackerweb";
-  let manifest = Manifest::builder(name)
-    .short_name("my app")
-    .bg_color("#000")
+  let manifest = Manifest::builder(name.into())
+    .short_name("my app".into())
+    .bg_color("#000".into())
     .related(&Related::new("play", url))
     .icon(&Icon::new("/icon.png", "48x48"))
     .pretty()?;

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -3,13 +3,11 @@
 ///
 /// ## Example
 /// ```rust
-/// # extern crate webmanifest;
-/// # extern crate failure;
 /// # use webmanifest::{Manifest, Direction};
 /// # fn main() -> Result<(), failure::Error> {
 /// let name = "My Cool Application";
 /// let lang = "en-US";
-/// let manifest = Manifest::builder(name)
+/// let manifest = Manifest::builder(name.into())
 ///   .direction(Direction::Ltr)
 ///   .build()?;
 /// # Ok(())}

--- a/src/display_mode.rs
+++ b/src/display_mode.rs
@@ -1,12 +1,10 @@
 /// Defines the developers’ preferred display mode for the website.
 /// ## Example
 /// ```rust
-/// # extern crate webmanifest;
-/// # extern crate failure;
 /// # use webmanifest::{Manifest, DisplayMode};
 /// # fn main() -> Result<(), failure::Error> {
 /// let name = "My Cool Application";
-/// let manifest = Manifest::builder(name)
+/// let manifest = Manifest::builder(name.into())
 ///   .display_mode(DisplayMode::Standalone)
 ///   .build()?;
 /// # Ok(())}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
 
 //! ## Example
 //! ```rust
-//! extern crate webmanifest;
-//! extern crate failure;
-//!
 //! use webmanifest::{Manifest, Related};
 //!
 //! fn main() -> Result<(), failure::Error> {
@@ -28,6 +25,8 @@ extern crate serde_json;
 extern crate serde_derive;
 
 use failure::Error;
+use std::marker::PhantomData;
+use std::str::FromStr;
 
 mod direction;
 mod display_mode;
@@ -46,30 +45,31 @@ pub const MIME_TYPE_STR: &str = "application/manifest+json";
 
 /// Create a new manifest builder.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Manifest<'s, 'i, 'r> {
-  name: &'s str,
+pub struct Manifest<'a, 'i, 'r> {
+  _input: PhantomData<&'a str>,
+  name: String,
   #[serde(skip_serializing_if = "Option::is_none")]
-  short_name: Option<&'s str>,
+  short_name: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  start_url: Option<&'s str>,
+  start_url: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
   #[serde(rename = "display")]
   display_mode: Option<DisplayMode>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  background_color: Option<&'s str>,
+  background_color: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  description: Option<&'s str>,
+  description: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
   #[serde(rename = "dir")]
   direction: Option<Direction>,
   #[serde(skip_serializing_if = "Option::is_none")]
   orientation: Option<Orientation>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  lang: Option<&'s str>,
+  lang: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  scope: Option<&'s str>,
+  scope: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
-  theme_color: Option<&'s str>,
+  theme_color: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
   prefer_related_applications: Option<bool>,
   #[serde(borrow)]
@@ -78,7 +78,7 @@ pub struct Manifest<'s, 'i, 'r> {
   related_applications: Vec<Related<'r>>,
 }
 
-impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
+impl<'a, 'i, 'r> Manifest<'a, 'i, 'r> {
   /// Create a new instance.
   ///
   /// ## Example
@@ -90,8 +90,9 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
   /// ```
   #[must_use]
   #[inline]
-  pub fn builder(name: &'s str) -> Self {
+  pub fn builder(name: String) -> Self {
     Self {
+      _input: PhantomData,
       name,
       short_name: None,
       description: None,
@@ -107,12 +108,6 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
       icons: vec![],
       related_applications: vec![],
     }
-  }
-
-  /// Create an instance from a string.
-  pub fn from_str(input: &'s str) -> Result<Self, Error> {
-    let manifest: Self = serde_json::from_str(input)?;
-    Ok(manifest)
   }
 
   /// Finalize the builder and create the manifest.
@@ -172,7 +167,7 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
   /// ```
   #[must_use]
   #[inline]
-  pub fn short_name(mut self, name: &'s str) -> Self {
+  pub fn short_name(mut self, name: String) -> Self {
     debug_assert!(name.len() <= 12);
     self.short_name = Some(name);
     self
@@ -194,7 +189,7 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
   /// ```
   #[must_use]
   #[inline]
-  pub fn start_url(mut self, url: &'s str) -> Self {
+  pub fn start_url(mut self, url: String) -> Self {
     self.start_url = Some(url);
     self
   }
@@ -236,7 +231,7 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
   /// ```
   #[must_use]
   #[inline]
-  pub fn bg_color(mut self, color: &'s str) -> Self {
+  pub fn bg_color(mut self, color: String) -> Self {
     self.background_color = Some(color);
     self
   }
@@ -257,7 +252,7 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
   /// ```
   #[must_use]
   #[inline]
-  pub fn theme_color(mut self, color: &'s str) -> Self {
+  pub fn theme_color(mut self, color: String) -> Self {
     self.theme_color = Some(color);
     self
   }
@@ -279,7 +274,7 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
   /// ```
   #[must_use]
   #[inline]
-  pub fn description(mut self, desc: &'s str) -> Self {
+  pub fn description(mut self, desc: String) -> Self {
     self.description = Some(desc);
     self
   }
@@ -304,7 +299,7 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
   /// ```
   #[must_use]
   #[inline]
-  pub fn lang(mut self, lang: &'s str) -> Self {
+  pub fn lang(mut self, lang: String) -> Self {
     self.lang = Some(lang);
     self
   }
@@ -414,7 +409,7 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
   /// ```
   #[must_use]
   #[inline]
-  pub fn scope(mut self, scope: &'s str) -> Self {
+  pub fn scope(mut self, scope: String) -> Self {
     self.scope = Some(scope);
     self
   }
@@ -462,4 +457,13 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
     self.related_applications.push(related.clone());
     self
   }
+
+  //   fn from_str(input: &'a str) -> Result<Self, Error> {
+  //     let manifest: Self = serde_json::from_str(&input)?;
+  //     Ok(manifest)
+  //   }
 }
+
+// impl<'a, 'i, 'r> FromStr for Manifest<'a, 'i, 'r> {
+//   type Err = Error;
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ extern crate serde_derive;
 
 use failure::Error;
 use std::marker::PhantomData;
-use std::str::FromStr;
+// use std::str::FromStr;
 
 mod direction;
 mod display_mode;
@@ -34,11 +34,11 @@ mod icon;
 mod orientation;
 mod related;
 
-pub use direction::Direction;
-pub use display_mode::DisplayMode;
-pub use icon::Icon;
-pub use orientation::Orientation;
-pub use related::Related;
+pub use crate::direction::Direction;
+pub use crate::display_mode::DisplayMode;
+pub use crate::icon::Icon;
+pub use crate::orientation::Orientation;
+pub use crate::related::Related;
 
 /// The MIME type for `.webmanifest` files.
 pub const MIME_TYPE_STR: &str = "application/manifest+json";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,17 +8,15 @@
 //! fn main() -> Result<(), failure::Error> {
 //!   let name = "My Cool Application";
 //!   let url = "https://play.google.com/store/apps/details?id=cheeaun.hackerweb";
-//!   let manifest = Manifest::builder(name)
-//!     .short_name("my app")
-//!     .bg_color("#000")
+//!   let manifest = Manifest::builder(name.into())
+//!     .short_name("my app".into())
+//!     .bg_color("#000".into())
 //!     .related(&Related::new("play", url))
 //!     .build()?;
 //!   Ok(())
 //! }
 //! ```
 
-extern crate failure;
-extern crate mime_guess;
 extern crate serde;
 extern crate serde_json;
 #[macro_use]
@@ -80,10 +78,9 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
   /// # use webmanifest::Manifest;
   /// let name = "My Cool Application";
-  /// let builder = Manifest::builder(name);
+  /// let builder = Manifest::builder(name.into());
   /// ```
   #[must_use]
   #[inline]
@@ -110,12 +107,10 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::Manifest;
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name).build()?;
+  /// let manifest = Manifest::builder(name.into()).build()?;
   /// # Ok(())}
   /// ```
   #[must_use]
@@ -129,12 +124,10 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::Manifest;
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name).pretty()?;
+  /// let manifest = Manifest::builder(name.into()).pretty()?;
   /// # Ok(())}
   /// ```
   #[must_use]
@@ -151,13 +144,11 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::Manifest;
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name)
-  ///   .short_name("Cool App")
+  /// let manifest = Manifest::builder(name.into())
+  ///   .short_name("Cool App".into())
   ///   .build()?;
   /// # Ok(())}
   /// ```
@@ -165,7 +156,7 @@ impl<'i, 'r> Manifest<'i, 'r> {
   #[inline]
   pub fn short_name(mut self, name: String) -> Self {
     debug_assert!(name.len() <= 12);
-    self.short_name = Some(name);
+    self.short_name = Some(name.into());
     self
   }
 
@@ -173,13 +164,11 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::Manifest;
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name)
-  ///   .start_url(".")
+  /// let manifest = Manifest::builder(name.into())
+  ///   .start_url(".".into())
   ///   .build()?;
   /// # Ok(())}
   /// ```
@@ -194,12 +183,10 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::{Manifest, DisplayMode};
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name)
+  /// let manifest = Manifest::builder(name.into())
   ///   .display_mode(DisplayMode::Standalone)
   ///   .build()?;
   /// # Ok(())}
@@ -215,13 +202,11 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::Manifest;
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name)
-  ///   .bg_color("#000")
+  /// let manifest = Manifest::builder(name.into())
+  ///   .bg_color("#000".into())
   ///   .build()?;
   /// # Ok(())}
   /// ```
@@ -236,13 +221,11 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::Manifest;
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name)
-  ///   .theme_color("#000")
+  /// let manifest = Manifest::builder(name.into())
+  ///   .theme_color("#000".into())
   ///   .build()?;
   /// # Ok(())}
   /// ```
@@ -257,14 +240,12 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::Manifest;
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
   /// let desc = "It does many things.";
-  /// let manifest = Manifest::builder(name)
-  ///   .description(desc)
+  /// let manifest = Manifest::builder(name.into())
+  ///   .description(desc.into())
   ///   .build()?;
   /// # Ok(())}
   /// ```
@@ -282,14 +263,12 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::Manifest;
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
   /// let lang = "en-US";
-  /// let manifest = Manifest::builder(name)
-  ///   .lang(lang)
+  /// let manifest = Manifest::builder(name.into())
+  ///   .lang(lang.into())
   ///   .build()?;
   /// # Ok(())}
   /// ```
@@ -309,12 +288,10 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::{Manifest, Orientation};
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name)
+  /// let manifest = Manifest::builder(name.into())
   ///   .orientation(Orientation::Portrait)
   ///   .build()?;
   /// # Ok(())}
@@ -334,13 +311,11 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::{Manifest, Direction};
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
   /// let lang = "en-US";
-  /// let manifest = Manifest::builder(name)
+  /// let manifest = Manifest::builder(name.into())
   ///   .direction(Direction::Ltr)
   ///   .build()?;
   /// # Ok(())}
@@ -364,12 +339,10 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::{Manifest, Direction};
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name)
+  /// let manifest = Manifest::builder(name.into())
   ///   .prefer_related_applications(true)
   ///   .build()?;
   /// # Ok(())}
@@ -393,13 +366,11 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::{Manifest, Direction};
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
-  /// let manifest = Manifest::builder(name)
-  ///   .scope("/myapp/")
+  /// let manifest = Manifest::builder(name.into())
+  ///   .scope("/myapp/".into())
   ///   .build()?;
   /// # Ok(())}
   /// ```
@@ -414,13 +385,11 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::{Manifest, Icon};
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
   /// let src = "images/touch/homescreen48.png";
-  /// let manifest = Manifest::builder(name)
+  /// let manifest = Manifest::builder(name.into())
   ///   .icon(&Icon::new(&src, "48x48"))
   ///   .build()?;
   /// # Ok(())}
@@ -436,13 +405,11 @@ impl<'i, 'r> Manifest<'i, 'r> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
-  /// # extern crate failure;
   /// # use webmanifest::{Manifest, Related};
   /// # fn main() -> Result<(), failure::Error> {
   /// let name = "My Cool Application";
   /// let url = "https://play.google.com/store/apps/details?id=cheeaun.hackerweb";
-  /// let manifest = Manifest::builder(name)
+  /// let manifest = Manifest::builder(name.into())
   ///   .related(&Related::new("play", url))
   ///   .build()?;
   /// # Ok(())}
@@ -454,3 +421,12 @@ impl<'i, 'r> Manifest<'i, 'r> {
     self
   }
 }
+
+// impl<'i, 'r> std::str::FromStr for &Manifest<'i, 'r> {
+//   type Err = Error;
+
+//   fn from_str(s: &str) -> Result<Self, Self::Err> {
+//     let manifest: Manifest = serde_json::from_str(s)?;
+//     Ok(&manifest)
+//   }
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,12 @@ impl<'s, 'i, 'r> Manifest<'s, 'i, 'r> {
     }
   }
 
+  /// Create an instance from a string.
+  pub fn from_str(input: &'s str) -> Result<Self, Error> {
+    let manifest: Self = serde_json::from_str(input)?;
+    Ok(manifest)
+  }
+
   /// Finalize the builder and create the manifest.
   ///
   /// ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@ extern crate serde_json;
 extern crate serde_derive;
 
 use failure::Error;
-use std::marker::PhantomData;
-// use std::str::FromStr;
 
 mod direction;
 mod display_mode;
@@ -45,8 +43,7 @@ pub const MIME_TYPE_STR: &str = "application/manifest+json";
 
 /// Create a new manifest builder.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Manifest<'a, 'i, 'r> {
-  _input: PhantomData<&'a str>,
+pub struct Manifest<'i, 'r> {
   name: String,
   #[serde(skip_serializing_if = "Option::is_none")]
   short_name: Option<String>,
@@ -78,7 +75,7 @@ pub struct Manifest<'a, 'i, 'r> {
   related_applications: Vec<Related<'r>>,
 }
 
-impl<'a, 'i, 'r> Manifest<'a, 'i, 'r> {
+impl<'i, 'r> Manifest<'i, 'r> {
   /// Create a new instance.
   ///
   /// ## Example
@@ -92,7 +89,6 @@ impl<'a, 'i, 'r> Manifest<'a, 'i, 'r> {
   #[inline]
   pub fn builder(name: String) -> Self {
     Self {
-      _input: PhantomData,
       name,
       short_name: None,
       description: None,
@@ -457,13 +453,4 @@ impl<'a, 'i, 'r> Manifest<'a, 'i, 'r> {
     self.related_applications.push(related.clone());
     self
   }
-
-  //   fn from_str(input: &'a str) -> Result<Self, Error> {
-  //     let manifest: Self = serde_json::from_str(&input)?;
-  //     Ok(manifest)
-  //   }
 }
-
-// impl<'a, 'i, 'r> FromStr for Manifest<'a, 'i, 'r> {
-//   type Err = Error;
-// }

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -3,12 +3,10 @@
 ///
 /// ## Example
 /// ```rust
-/// # extern crate webmanifest;
-/// # extern crate failure;
 /// # use webmanifest::{Manifest, Orientation};
 /// # fn main() -> Result<(), failure::Error> {
 /// let name = "My Cool Application";
-/// let manifest = Manifest::builder(name)
+/// let manifest = Manifest::builder(name.into())
 ///   .orientation(Orientation::Portrait)
 ///   .build()?;
 /// # Ok(())}

--- a/src/related.rs
+++ b/src/related.rs
@@ -24,7 +24,6 @@ impl<'s> Related<'s> {
   ///
   /// ## Example
   /// ```rust
-  /// # extern crate webmanifest;
   /// # use webmanifest::Related;
   /// let platform = "play";
   /// let url = "https://play.google.com/store/apps/details?id=cheeaun.hackerweb";

--- a/tests/fixtures/manifest-1.json
+++ b/tests/fixtures/manifest-1.json
@@ -1,0 +1,37 @@
+{
+  "name": "HackerWeb",
+  "short_name": "HackerWeb",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#fff",
+  "description": "A simply readable Hacker News app.",
+  "icons": [{
+    "src": "images/touch/homescreen48.png",
+    "sizes": "48x48",
+    "type": "image/png"
+  }, {
+    "src": "images/touch/homescreen72.png",
+    "sizes": "72x72",
+    "type": "image/png"
+  }, {
+    "src": "images/touch/homescreen96.png",
+    "sizes": "96x96",
+    "type": "image/png"
+  }, {
+    "src": "images/touch/homescreen144.png",
+    "sizes": "144x144",
+    "type": "image/png"
+  }, {
+    "src": "images/touch/homescreen168.png",
+    "sizes": "168x168",
+    "type": "image/png"
+  }, {
+    "src": "images/touch/homescreen192.png",
+    "sizes": "192x192",
+    "type": "image/png"
+  }],
+  "related_applications": [{
+    "platform": "play",
+    "url": "https://play.google.com/store/apps/details?id=cheeaun.hackerweb"
+  }]
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,15 @@
+extern crate failure;
+extern crate serde_json;
+extern crate webmanifest;
+
+use webmanifest::Manifest;
+
+use std::fs;
+
+#[test]
+fn deserialize() -> Result<(), failure::Error> {
+  let location = "tests/fixtures/manifest-1.json";
+  let content = fs::read_to_string(location)?;
+  println!("{:?}", content);
+  Ok(())
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,3 @@
-extern crate failure;
-extern crate serde_json;
-extern crate webmanifest;
-
 use webmanifest::Manifest;
 
 use std::fs;
@@ -10,6 +6,13 @@ use std::fs;
 fn deserialize() -> Result<(), failure::Error> {
   let location = "tests/fixtures/manifest-1.json";
   let content = fs::read_to_string(location)?;
-  println!("{:?}", content);
+  let _manifest: Manifest = serde_json::from_str(&content)?;
+
+  // assert_eq!(manifest.name(), Some("hackerweb".to_string()));
+  // assert_eq!(manifest.short_name(), "HackerWeb");
+  // assert_eq!(manifest.start_url(), ".");
+  // assert_eq!(manifest.display(), webmanifest::DisplayMode::Standalone);
+  // assert_eq!(manifest.background_color(), "#fff");
+  // assert_eq!(manifest.description(), "A simply readable Hacker News app.".to_string());
   Ok(())
 }


### PR DESCRIPTION
First PR in a series to implement #3. We'll need to do some more breaking changes after this patch lands, so we can't deploy it quite yet. But this gets us part of the way.

## Changes
- upgrades us to rust 2018
- implements owned data structures so `Deserialize` works
- adds some basic tests to prove deserialize works

## Not included
- no `std::str::FromStr` conversion
- no accessing of properties; we need to split the builder from the actual manifest implementation
- which means no tests for those either